### PR TITLE
Missing project_category column

### DIFF
--- a/tap_jira_sdk/tap.py
+++ b/tap_jira_sdk/tap.py
@@ -55,22 +55,22 @@ class TapJira(Tap):
             A list of discovered streams.
         """
         return [
-            #streams.UsersStream(self),
-            #streams.FieldStream(self),
-            #streams.ServerInfoStream(self),
-            #streams.IssueTypeStream(self),
-            #streams.ProjectStream(self),
-            #streams.StatusStream(self),
+            streams.UsersStream(self),
+            streams.FieldStream(self),
+            streams.ServerInfoStream(self),
+            streams.IssueTypeStream(self),
+            streams.ProjectStream(self),
+            streams.StatusStream(self),
             streams.IssueStream(self),
-            #streams.SearchStream(self),
-            #streams.PermissionStream(self),
-            #streams.ProjectRoleStream(self),
-            #streams.PriorityStream(self),
-            #streams.PermissionHolderStream(self),
-            #streams.SprintStream(self),
-            #streams.UserGroupTrustedStream(self),
-            #streams.ProjectRoleAtlassianActorStream(self),
-            #streams.IssueWatcherStream(self),
+            streams.SearchStream(self),
+            streams.PermissionStream(self),
+            streams.ProjectRoleStream(self),
+            streams.PriorityStream(self),
+            streams.PermissionHolderStream(self),
+            streams.SprintStream(self),
+            streams.UserGroupTrustedStream(self),
+            streams.ProjectRoleAtlassianActorStream(self),
+            streams.IssueWatcherStream(self),
         ]
 
 


### PR DESCRIPTION
This PR adds the missing project_category field in the Project stream.

Ticket: [DATA-3573](https://ryan-miranda.atlassian.net/browse/DATA-3573)

[DATA-3573]: https://ryan-miranda.atlassian.net/browse/DATA-3573?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ