### PR TITLE
feat: Allow IssuesStreams to be filtered with JQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Built with the [Meltano Singer SDK](https://sdk.meltano.com).
 | api_token           | True     | None    | Jira API Token. |
 | Email               | True     | None    | The user email for your Jira account. |
 | page_size           | False    | None    |             |
+| issues_jql          | False    | None    | An optional Base JQL query for issue searches. | 
 | stream_maps         | False    | None    | Config object for stream maps capability. For more information check out [Stream Maps](https://sdk.meltano.com/en/latest/stream_maps.html). |
 | stream_map_config   | False    | None    | User-defined config values to be used within map expressions. |
 | flattening_enabled  | False    | None    | 'True' to enable schema flattening and automatically expand nested properties. |

--- a/meltano.yml
+++ b/meltano.yml
@@ -24,6 +24,7 @@ plugins:
     - name: auth.username
     - name: auth.password
       kind: password
+    - name: issues_jql
 environments:
 - name: dev
 - name: staging

--- a/tap_jira/streams.py
+++ b/tap_jira/streams.py
@@ -1631,11 +1631,11 @@ class IssueStream(JiraStream):
 
         if "start_date" in self.config:
             start_date = self.config["start_date"]
-            params["jql"].append(f"(created>={start_date} or updated>={start_date})")
+            params["jql"].append(f"(created>='{start_date}' or updated>='{start_date}')")
 
         if "end_date" in self.config:
             end_date = self.config["end_date"]
-            params["jql"].append(f"(created<{end_date} or updated<{end_date})")
+            params["jql"].append(f"(created<'{end_date}' or updated<'{end_date}')")
 
         if params["jql"]:
             jql = " and ".join(params["jql"])

--- a/tap_jira/streams.py
+++ b/tap_jira/streams.py
@@ -1637,6 +1637,10 @@ class IssueStream(JiraStream):
             end_date = self.config["end_date"]
             params["jql"].append(f"(created<'{end_date}' or updated<'{end_date}')")
 
+        if "issues_jql" in self.config:
+            base_jql = self.config["issues_jql"]
+            params["jql"].append(f"({base_jql})")
+
         if params["jql"]:
             jql = " and ".join(params["jql"])
             params["jql"] = jql

--- a/tap_jira/streams.py
+++ b/tap_jira/streams.py
@@ -1635,7 +1635,7 @@ class IssueStream(JiraStream):
 
         if "end_date" in self.config:
             end_date = self.config["end_date"]
-            params["jql"].append(f"(created<{end_date} or updated<{start_date})")
+            params["jql"].append(f"(created<{end_date} or updated<{end_date})")
 
         if params["jql"]:
             jql = " and ".join(params["jql"])

--- a/tap_jira/tap.py
+++ b/tap_jira/tap.py
@@ -53,6 +53,11 @@ class TapJira(Tap):
                 ),
             ),
         ),
+        th.Property(
+            "issues_jql",
+            th.StringType,
+            description="An optional Base JQL query for issue searches",
+        ),
     ).to_dict()
 
     def discover_streams(self) -> list[streams.JiraStream]:


### PR DESCRIPTION
My org's Jira instance contains hundreds of thousands of issues spanning 15+ years of history, and we simply don't care about mirroring / analyzing the vast majority of them via Meltano & friends. Accordingly, it would be _great_ to be able to filter out huge swaths of issues at the tap level by passing in a JQL query, so that's what I've implemented here.

New config parameter `issues_jql` is a string defining a self-contained JQL clause, ex:
```
issues_jql: "project = FOO and issueType = Bug"
```

This JQL string can be arbitrarily complex, and if provided it will be included as a separate clause alongside start date / end date clauses, so this sample config:

```
start_date: "2024-12-08"
end_date: "2024-12-09"
issues_jql: "project = FOO"
```

will evaluate to the JQL query:

```
(created>='2024-12-08' or updated>='2024-12-08') and (created<'2024-12-09' or updated<'2024-12-09') and (project = FOO)
```

Note that while I was working on the `IssueStream.get_url_params()` method I tripped over two other issues, which I've resolved:
- `end_date` was filtering by `updated<'{start_date}'` instead of `end_date`
- start / end dates were being passed into the JQL un-quoted, so you could not pass in a time, only a literal date
  - If interested, I can file a follow-up PR that handles parsing a full ISO8601 timestamp into the awful format required by JQL