### PR TITLE
feat: add support for boards without sprints

### DIFF
--- a/tap_jira/streams.py
+++ b/tap_jira/streams.py
@@ -8,7 +8,6 @@ import typing as t
 from http import HTTPStatus
 
 from singer_sdk import typing as th  # JSON Schema typing helpers
-from singer_sdk.exceptions import FatalAPIError
 
 from tap_jira.client import JiraStream
 
@@ -2394,16 +2393,13 @@ class SprintStream(JiraStream):
         Allow for a 400 response if the board does not support sprints.
         Do raise an error for other 400 responses.
         """
-        try:
-            super().validate_response(response)
-        except FatalAPIError:
-            if (
-                response.status_code == HTTPStatus.BAD_REQUEST
-                and "The board does not support sprints"
-                in response.json().get("errorMessages", [])
-            ):
-                return
-            raise
+        if (
+            response.status_code == HTTPStatus.BAD_REQUEST
+            and "The board does not support sprints"
+            in response.json().get("errorMessages", [])
+        ):
+            return
+        super().validate_response(response)
 
 
 class ProjectRoleActorStream(JiraStream):

--- a/tap_jira/streams.py
+++ b/tap_jira/streams.py
@@ -2405,6 +2405,7 @@ class SprintStream(JiraStream):
                 return
             raise
 
+
 class ProjectRoleActorStream(JiraStream):
     """Project role actor stream.
 


### PR DESCRIPTION
We have some boards without sprints and they fail with a BAD_REQUEST http error when the tap tries to get the sprints from the boards, so this PR is to make them not raise an exception and continue.
