### PR TITLE
chore: pin GitHub Actions versions to commit hashes

### DIFF
--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -32,11 +32,11 @@ jobs:
   linting:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
       with:
         python-version: 3.x
-    - uses: astral-sh/setup-uv@v5
+    - uses: astral-sh/setup-uv@f94ec6bedd8674c4426838e6b50417d36b6ab231 # v5.3.1
       with:
         version: ">=0.5"
     - run: uvx --with tox-uv tox -e lint
@@ -54,11 +54,11 @@ jobs:
         - "3.10"
         - "3.9"
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
       with:
         python-version: ${{ matrix.python-version }}
-    - uses: astral-sh/setup-uv@v5
+    - uses: astral-sh/setup-uv@f94ec6bedd8674c4426838e6b50417d36b6ab231 # v5.3.1
       with:
         version: ">=0.5"
     - name: Test with pytest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,12 +17,12 @@ jobs:
       PIP_CONSTRAINT: .github/workflows/constraints.txt
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version: "3.10"
 
@@ -40,7 +40,7 @@ jobs:
         run: poetry build
 
       - name: Upload wheel to release
-        uses: svenstaro/upload-release-action@v2
+        uses: svenstaro/upload-release-action@04733e069f2d7f7f0b4aebc4fbdbce8613b03ccd # 2.9.0
         with:
           file: dist/*.whl
           tag: ${{ github.ref }}
@@ -48,4 +48,4 @@ jobs:
           file_glob: true
 
       - name: Publish
-        uses: pypa/gh-action-pypi-publish@v1.12.4
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4


### PR DESCRIPTION
This will help prevent attacks such as [this one](https://semgrep.dev/blog/2025/popular-github-action-tj-actionschanged-files-is-compromised/).

Dependabot is able to update these versions automatically, and it will preserve the readable version comments.
