### PR TITLE
fix: Add primary key for sprints, fix too long of a column name

### DIFF
--- a/tap_jira/streams.py
+++ b/tap_jira/streams.py
@@ -2347,6 +2347,7 @@ class SprintStream(JiraStream):
     """
 
     name = "sprints"
+    primary_keys = ("id",)
     parent_stream_type = BoardStream
     path = "/board/{board_id}/sprint?maxResults=100"
     replication_method = "INCREMENTAL"

--- a/tap_jira/streams.py
+++ b/tap_jira/streams.py
@@ -147,10 +147,7 @@ class FieldStream(JiraStream):
                         Property("customRenderer", BooleanType),
                         Property("readOnly", BooleanType),
                         Property("environment", StringType),
-                        Property(
-                            "com.atlassian.jira.plugin.system.customfieldtypes:atlassian-team",
-                            BooleanType,
-                        ),
+                        Property("atlassian_team", BooleanType),
                     ),
                 ),
             ),


### PR DESCRIPTION
* Getting duplicate entries for each sprint because no primary key was specified.
* When unfurling depth > 1 postgres would fail out because the column name was too long, simplified that.