### PR TITLE
feat: add releaseDate property for issues' fix versions

### DIFF
--- a/tap_jira/streams.py
+++ b/tap_jira/streams.py
@@ -676,6 +676,7 @@ class IssueStream(JiraStream):
                         Property("id", StringType),
                         Property("name", StringType),
                         Property("self", StringType),
+                        Property("releaseDate", StringType),
                     ),
                 ),
                 Property("resolutiondate", StringType),


### PR DESCRIPTION
Hi,

As seen in the body response of the following Jira REST API endpoint:

_/tap_jira/streams.py:381_
```
class IssueStream(JiraStream):
    """Issue stream.

    https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-search/#api-rest-api-3-search-get
    """
    
    ...
```

I'd like to add the releaseDate property from the fixVersions field of issues, as I need this data for extraction.

Thank you for taking the time to review this pull request.

Best regards,
Evan Guyot