### PR TITLE
Update IssueStream to use new API endpoint since old endpoint was removed

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,19 +23,20 @@ Built with the [Meltano Singer SDK](https://sdk.meltano.com).
 
 ## Settings
 
-| Setting                   | Required | Default | Description                                                  |
-| :------------------------ | :------- | :------ | :----------------------------------------------------------- |
-| start_date                | False    | None    | Earliest record date to sync                                 |
-| end_date                  | False    | None    | Latest record date to sync                                   |
-| domain                    | True     | None    | The Domain for your Jira account, e.g. meltano.atlassian.net |
-| api_token                 | True     | None    | Jira API Token.                                              |
-| email                     | True     | None    | The user email for your Jira account.                        |
-| page_size                 | False    | None    |                                                              |
-| page_size.issues          | False    | 100     | Page size for issues stream                                  |
-| stream_options            | False    | None    | Options for individual streams                               |
-| stream_options.issues     | False    | None    | Options specific to the issues stream                        |
-| stream_options.issues.jql | False    | None    | A JQL query to filter issues                                 |
-| include_audit_logs        | False    | False   | Include the audit logs stream                                |
+| Setting                      | Required | Default | Description                                                                      |
+|:-----------------------------| :------- |:--------|:---------------------------------------------------------------------------------|
+| start_date                   | False    | None    | Earliest record date to sync                                                     |
+| end_date                     | False    | None    | Latest record date to sync                                                       |
+| domain                       | True     | None    | The Domain for your Jira account, e.g. meltano.atlassian.net                     |
+| api_token                    | True     | None    | Jira API Token.                                                                  |
+| email                        | True     | None    | The user email for your Jira account.                                            |
+| page_size                    | False    | None    |                                                                                  |
+| page_size.issues             | False    | 100     | Page size for issues stream                                                      |
+| stream_options               | False    | None    | Options for individual streams                                                   |
+| stream_options.issues        | False    | None    | Options specific to the issues stream                                            |
+| stream_options.issues.jql    | False    | None    | A JQL query to filter issues                                                     |
+| stream_options.issues.fields | False    | *all    | A comma-separated list of fields to include. All fields are included by default. |
+| include_audit_logs           | False    | False   | Include the audit logs stream                                                    |
 
 ### Built-in capabilities
 

--- a/tap_jira/streams.py
+++ b/tap_jira/streams.py
@@ -1692,9 +1692,7 @@ class IssueStream(JiraStream):
 
         params["maxResults"] = self.config.get("page_size", {}).get("issues", 10)
         params["fields"] = (
-            self.config.get("stream_options", {})
-            .get("issues", {})
-            .get("fields")
+            self.config.get("stream_options", {}).get("issues", {}).get("fields")
         )
         params["expand"] = "renderedFields"
 

--- a/tap_jira/streams.py
+++ b/tap_jira/streams.py
@@ -1694,7 +1694,6 @@ class IssueStream(JiraStream):
         params["fields"] = (
             self.config.get("stream_options", {}).get("issues", {}).get("fields")
         )
-        params["expand"] = "renderedFields"
 
         jql: list[str] = []
 

--- a/tap_jira/streams.py
+++ b/tap_jira/streams.py
@@ -1694,7 +1694,7 @@ class IssueStream(JiraStream):
         params["fields"] = (
             self.config.get("stream_options", {})
             .get("issues", {})
-            .get("fields", "*all")
+            .get("fields")
         )
         params["expand"] = "renderedFields"
 

--- a/tap_jira/streams.py
+++ b/tap_jira/streams.py
@@ -1718,8 +1718,6 @@ class IssueStream(JiraStream):
         ):
             jql.append(f"({base_jql})")
 
-        if jql:
-            params["jql"] = " and ".join(jql)
         params["jql"] = " and ".join(jql) + f" order by {self.replication_key} asc"
 
         return params

--- a/tap_jira/tap.py
+++ b/tap_jira/tap.py
@@ -72,6 +72,7 @@ class TapJira(Tap):
                             th.StringType,
                             description="A comma-separated list of fields to include",
                             title="Fields",
+                            default="*all",
                         ),
                     ),
                     title="Issues Stream Options",

--- a/tap_jira/tap.py
+++ b/tap_jira/tap.py
@@ -67,6 +67,12 @@ class TapJira(Tap):
                             description="A JQL query to filter issues",
                             title="JQL Query",
                         ),
+                        th.Property(
+                            "fields",
+                            th.StringType,
+                            description="A comma-separated list of fields to include",
+                            title="Fields",
+                        ),
                     ),
                     title="Issues Stream Options",
                     description="Options specific to the issues stream",


### PR DESCRIPTION
The `/search` endpoint which is used by `IssueStream` has been deprecated for a while and was removed yesterday (at least for my Jira instance).

This PR updates `IssueStream` to make use of the new `/search/jql` endpoint which is mostly a drop-in replacement. The only notable change in the new endpoint is that it takes a `nextPageToken` parameter, which means I had to fix pagination.

I have also introduced a `fields` option so tap users can easily manage a whitelist/blacklist of the fields they want to include/exclude in the Jira stream.

Let me know if there are any questions or if I need to make any changes!