### PR TITLE
fix: Incorrect `security` issue property schema

### DIFF
--- a/tap_jira/streams.py
+++ b/tap_jira/streams.py
@@ -1664,7 +1664,15 @@ class IssueStream(JiraStream[str]):
                     ),
                 ),
                 Property("timetracking", ObjectType(additional_properties=True)),
-                Property("security", StringType),
+                Property(
+                    "security",
+                    ObjectType(
+                        Property("self", StringType),
+                        Property("id", StringType),
+                        Property("description", StringType),
+                        Property("name", StringType),
+                    ),
+                ),
                 Property("aggregatetimeestimate", IntegerType),
                 Property(
                     "attachment",


### PR DESCRIPTION
Getting

```
singer_sdk.exceptions.InvalidRecord: Record Message Validation Error: {...} is not of type 'string', 'null'
```

when running with `target-snowflake`.