### PR TITLE
fix: force English-language responses from Jira Cloud API

### DIFF
--- a/tap_jira/client.py
+++ b/tap_jira/client.py
@@ -61,6 +61,21 @@ class JiraStream(RESTStream[_TNextPageToken]):
         )
 
     @override
+    @property
+    def http_headers(self) -> dict[str, str]:
+        """Force English-language responses from the Jira Cloud API.
+
+        Without this, error messages (e.g. "The board does not support
+        sprints") are localized to the API user's profile language, which
+        breaks string-matching in ``validate_response`` overrides.
+        See https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro/#special-request-headers
+        """
+        headers: dict[str, str] = super().http_headers
+        headers["Accept-Language"] = "en"
+        headers["X-Force-Accept-Language"] = "true"
+        return headers
+
+    @override
     def get_records(self, context: Context | None) -> Iterable[dict[str, Any]]:
         try:
             yield from super().get_records(context)

--- a/tests/test_http_headers.py
+++ b/tests/test_http_headers.py
@@ -1,0 +1,29 @@
+"""Tests for HTTP headers set on every Jira request."""
+
+from __future__ import annotations
+
+from tap_jira.streams import IssueStream
+from tap_jira.tap import TapJira
+
+
+class TestForceEnglishHeaders:
+    """Headers forcing English-language API responses must be present."""
+
+    def test_accept_language_headers_present(self) -> None:
+        """Both ``Accept-Language`` and ``X-Force-Accept-Language`` are sent.
+
+        Jira Cloud localizes error messages to the API user's profile
+        language. ``X-Force-Accept-Language: true`` together with
+        ``Accept-Language: en`` overrides that, keeping ``validate_response``
+        string-matching reliable for non-English users.
+        """
+        tap = TapJira(
+            config={
+                "domain": "test.atlassian.net",
+                "email": "test@example.com",
+                "api_token": "test-token",
+            },
+        )
+        headers = IssueStream(tap).http_headers
+        assert headers["Accept-Language"] == "en"
+        assert headers["X-Force-Accept-Language"] == "true"


### PR DESCRIPTION
## Problem

`SprintStream.validate_response` (and any future `validate_response` override that pattern-matches on `errorMessages`) silently breaks for users whose Jira Cloud account language is not English. Jira localizes API error messages based on the calling user's profile locale, so:

- English account: `"The board does not support sprints"` → check passes, board is skipped, sync continues.
- Non-English account (e.g. Russian): `"Данная доска не поддерживает спринты"` → check fails, the 400 propagates, the entire Meltano run aborts on the first non-Scrum board.

This was hit in the wild on a Russian-locale Atlassian account — `validate_response` raised, killing the whole tap.

## Fix

Set `Accept-Language: en` together with `X-Force-Accept-Language: true` on every request from `JiraStream`. Per the [Jira Cloud REST API docs](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro/#special-request-headers), `Accept-Language` is normally ignored on Atlassian Cloud unless `X-Force-Accept-Language: true` is also present; together they force English responses regardless of the API user's profile locale.

This makes the existing English string-matching reliable for all users, and is robust to any future `validate_response` overrides that key off error text.

## Scope / compatibility

- **Jira Cloud:** fully supported — both headers are documented.
- **Jira Server / Data Center:** the `X-Force-Accept-Language` header is ignored (tracked upstream as `JRASERVER-74088`), so behavior on Server is unchanged — no regression.
- **Existing English-locale users:** no behavioral change; they were already getting English responses.

## Tests

- New `tests/test_http_headers.py` asserts both headers are present on a stream's `http_headers`.
- Manually verified end-to-end against a Russian-locale Atlassian Cloud account: before the patch, `meltano run tap-jira target-sqlite` failed on the first sprint-less board with `errorMessages: ["Данная доска не поддерживает спринты"]`. After the patch, the same run gets `"The board does not support sprints"` and the existing `validate_response` swallows it; sync completes normally.
