### PR TITLE
fix: Missing `include_audit_logs` setting definition in `meltano.yml`

### DIFF
--- a/meltano.yml
+++ b/meltano.yml
@@ -44,7 +44,7 @@ plugins:
       description: A JQL query to filter issues
     - name: include_audit_logs
       kind: boolean
-      value: true
+      value: false
       description: Include the audit logs stream
 environments:
 - name: dev

--- a/meltano.yml
+++ b/meltano.yml
@@ -42,6 +42,10 @@ plugins:
     - name: stream_options.issues.jql
       kind: string
       description: A JQL query to filter issues
+    - name: include_audit_logs
+      kind: boolean
+      value: true
+      description: Include the audit logs stream
 environments:
 - name: dev
 - name: staging


### PR DESCRIPTION
No code changes were required. The existing audit_records stream already captures hard-deleted Jira issues — records with objectItem.typeName set to ISSUE_DELETE contain the issue key and deletion timestamp.

The only relevant change was declaring include_audit_logs as a boolean setting in meltano.yml. Without this declaration, Meltano did not recognise the setting during catalog discovery in the context of this project, causing audit_records to be absent from the generated catalog even when TAP_JIRA_INCLUDE_AUDIT_LOGS
was set at runtime.

Note: if you do not have a paid Jira plan, keep this value as false — audit logs are unavailable on Free plans and will cause the run to fail.