### PR TITLE
feat: Support the `expand` parameter for issues and issue comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ Built with the [Meltano Singer SDK](https://sdk.meltano.com).
 | stream_options.issues        | False    | None       | Options specific to the issues stream                                            |
 | stream_options.issues.jql    | False    | id != null | A JQL query to filter issues                                                     |
 | stream_options.issues.fields | False    | *all       | A comma-separated list of fields to include. All fields are included by default. |
+| stream_options.issues.expand | False    | None       | A comma-separated list of entities to expand for issues, e.g. `renderedFields`.  |
+| stream_options.issue_comments | False   | None       | Options specific to the issue comments stream                                    |
+| stream_options.issue_comments.expand | False | None  | A comma-separated list of entities to expand for comments, e.g. `renderedBody`.  |
 | include_audit_logs           | False    | False      | Include the audit logs stream                                                    |
 
 ### Built-in capabilities

--- a/tap_jira/streams.py
+++ b/tap_jira/streams.py
@@ -1840,6 +1840,7 @@ class IssueStream(JiraStream[str]):
         ),
         Property("created", DateTimeType),
         Property("updated", DateTimeType),
+        Property("renderedFields", ObjectType(additional_properties=True)),
     ).to_dict()
 
     @override
@@ -1862,6 +1863,11 @@ class IssueStream(JiraStream[str]):
             .get("issues", {})
             .get("fields", "*all")
         )
+
+        if expand := (
+            self.config.get("stream_options", {}).get("issues", {}).get("expand")
+        ):
+            params["expand"] = expand
 
         jql: list[str] = []
 
@@ -3455,7 +3461,27 @@ class IssueComments(JiraStartAtPaginatedStream):
                 Property("active", BooleanType),
             ),
         ),
+        Property("renderedBody", StringType),
+        Property("jsdPublic", BooleanType),
     ).to_dict()
+
+    @override
+    def get_url_params(
+        self,
+        context: Context | None,
+        next_page_token: int | None,
+    ) -> dict[str, Any]:
+        """Return a dictionary of values to be used in URL parameterization."""
+        params = super().get_url_params(context, next_page_token)
+
+        if expand := (
+            self.config.get("stream_options", {})
+            .get("issue_comments", {})
+            .get("expand")
+        ):
+            params["expand"] = expand
+
+        return params
 
     @override
     def post_process(self, row: Record, context: Context | None = None) -> Record:

--- a/tap_jira/tap.py
+++ b/tap_jira/tap.py
@@ -99,9 +99,34 @@ class TapJira(Tap):
                             title="Fields",
                             default="*all",
                         ),
+                        th.Property(
+                            "expand",
+                            th.StringType,
+                            description=(
+                                "A comma-separated list of entities to expand, "
+                                "e.g. renderedFields"
+                            ),
+                            title="Expand",
+                        ),
                     ),
                     title="Issues Stream Options",
                     description="Options specific to the issues stream",
+                ),
+                th.Property(
+                    "issue_comments",
+                    th.ObjectType(
+                        th.Property(
+                            "expand",
+                            th.StringType,
+                            description=(
+                                "A comma-separated list of entities to expand, "
+                                "e.g. renderedBody"
+                            ),
+                            title="Expand",
+                        ),
+                    ),
+                    title="Issue Comments Stream Options",
+                    description="Options specific to the issue comments stream",
                 ),
             ),
             description="Options for individual streams",

--- a/tests/test_issue_comments_stream.py
+++ b/tests/test_issue_comments_stream.py
@@ -1,0 +1,35 @@
+"""Tests for IssueComments behavior."""
+
+from __future__ import annotations
+
+from tap_jira.streams import IssueComments
+from tap_jira.tap import TapJira
+
+BASE_CONFIG = {
+    "domain": "test.atlassian.net",
+    "email": "test@example.com",
+    "api_token": "test-token",
+}
+
+
+def test_get_url_params_expand_not_set() -> None:
+    tap = TapJira(config=BASE_CONFIG)
+
+    stream = IssueComments(tap)
+    params = stream.get_url_params(context=None, next_page_token=None)
+
+    assert "expand" not in params
+
+
+def test_get_url_params_expand() -> None:
+    tap = TapJira(
+        config={
+            **BASE_CONFIG,
+            "stream_options": {"issue_comments": {"expand": "renderedBody"}},
+        },
+    )
+
+    stream = IssueComments(tap)
+    params = stream.get_url_params(context=None, next_page_token=None)
+
+    assert params["expand"] == "renderedBody"

--- a/tests/test_issue_stream.py
+++ b/tests/test_issue_stream.py
@@ -56,3 +56,34 @@ def test_get_url_params_jql_start_and_end_date() -> None:
         "(created<'2026-02-01 00:00' or updated<'2026-02-01 00:00') and (id != null) "
         "order by updated asc"
     )
+
+
+def test_get_url_params_expand_not_set() -> None:
+    tap = TapJira(
+        config={
+            "domain": "test.atlassian.net",
+            "email": "test@example.com",
+            "api_token": "test-token",
+        },
+    )
+
+    stream = IssueStream(tap)
+    params = stream.get_url_params(context=None, next_page_token=None)
+
+    assert "expand" not in params
+
+
+def test_get_url_params_expand() -> None:
+    tap = TapJira(
+        config={
+            "domain": "test.atlassian.net",
+            "email": "test@example.com",
+            "api_token": "test-token",
+            "stream_options": {"issues": {"expand": "renderedFields"}},
+        },
+    )
+
+    stream = IssueStream(tap)
+    params = stream.get_url_params(context=None, next_page_token=None)
+
+    assert params["expand"] == "renderedFields"


### PR DESCRIPTION
Jira can return rendered (HTML) representations of issue fields and comment bodies via the `expand` query parameter, which is useful for downstream consumers that cannot render Atlassian Document Format.

Add `stream_options.issues.expand` and
`stream_options.issue_comments.expand` settings, a permissive `renderedFields` property on the issues schema, and the `renderedBody` and `jsdPublic` properties on the issue comments schema.