### PR TITLE
fix: Render JQL date literals in the Jira user's timezone

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Built with the [Meltano Singer SDK](https://sdk.meltano.com).
 |:-----------------------------|:---------|:-----------|:---------------------------------------------------------------------------------|
 | start_date                   | False    | None       | Earliest record date to sync                                                     |
 | end_date                     | False    | None       | Latest record date to sync                                                       |
+| timezone                     | False    | UTC        | IANA timezone name used to render date literals in JQL queries, e.g. Europe/Amsterdam. Should match the timezone of the authenticated Jira user. |
 | domain                       | True     | None       | The Domain for your Jira account, e.g. mycompany.atlassian.net                     |
 | api_token                    | True     | None       | Jira API Token.                                                                  |
 | email                        | True     | None       | The user email for your Jira account.                                            |

--- a/tap_jira/streams.py
+++ b/tap_jira/streams.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 import functools
 import operator
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
 from http import HTTPStatus
 from typing import TYPE_CHECKING, Any
+from zoneinfo import ZoneInfo
 
 from singer_sdk import typing as th  # JSON Schema typing helpers
 from singer_sdk.pagination import JSONPathPaginator, OffsetPaginator
@@ -1847,6 +1848,18 @@ class IssueStream(JiraStream[str]):
         """Return a new paginator for this stream."""
         return JSONPathPaginator(jsonpath=self.next_page_token_jsonpath)
 
+    def _format_jql_datetime(self, value: datetime) -> str:
+        """Format a datetime as a JQL date literal.
+
+        Jira evaluates JQL date literals in the timezone of the authenticated
+        user, so values are converted to the configured timezone first. Naive
+        values are assumed to be UTC.
+        """
+        tz = ZoneInfo(self.config.get("timezone") or "UTC")
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=timezone.utc)
+        return value.astimezone(tz).strftime("%Y-%m-%d %H:%M")
+
     @override
     def get_url_params(
         self,
@@ -1869,13 +1882,13 @@ class IssueStream(JiraStream[str]):
             params["nextPageToken"] = next_page_token
 
         if start_date := self.get_starting_timestamp(context):
-            start_date_fmt = start_date.strftime("%Y-%m-%d %H:%M")
+            start_date_fmt = self._format_jql_datetime(start_date)
 
             jql.append(f"(created>='{start_date_fmt}' or updated>='{start_date_fmt}')")
 
         if "end_date" in self.config:
             end_date = datetime.fromisoformat(self.config["end_date"])
-            end_date_fmt = end_date.strftime("%Y-%m-%d %H:%M")
+            end_date_fmt = self._format_jql_datetime(end_date)
 
             jql.append(f"(created<'{end_date_fmt}' or updated<'{end_date_fmt}')")
 

--- a/tap_jira/tap.py
+++ b/tap_jira/tap.py
@@ -40,6 +40,18 @@ class TapJira(Tap):
             description="Latest record date to sync",
         ),
         th.Property(
+            "timezone",
+            th.StringType,
+            description=(
+                "IANA timezone name used to render date literals in JQL queries, "
+                "e.g. Europe/Amsterdam. Jira evaluates JQL date literals in the "
+                "timezone of the authenticated user, so this should match the "
+                "timezone configured in that user's Jira profile."
+            ),
+            title="Timezone",
+            default="UTC",
+        ),
+        th.Property(
             "domain",
             th.StringType,
             description="The Domain for your Jira account, e.g. meltano.atlassian.net",

--- a/tests/test_issue_stream.py
+++ b/tests/test_issue_stream.py
@@ -56,3 +56,31 @@ def test_get_url_params_jql_start_and_end_date() -> None:
         "(created<'2026-02-01 00:00' or updated<'2026-02-01 00:00') and (id != null) "
         "order by updated asc"
     )
+
+
+def test_get_url_params_jql_timezone() -> None:
+    tap = TapJira(
+        config={
+            "domain": "test.atlassian.net",
+            "email": "test@example.com",
+            "api_token": "test-token",
+            "timezone": "Europe/Amsterdam",
+            "end_date": "2026-02-01T00:00:00",
+        },
+        state={
+            "bookmarks": {
+                "issues": {
+                    "starting_replication_value": "2026-01-01T12:34:56",
+                },
+            },
+        },
+    )
+
+    stream = IssueStream(tap)
+    params = stream.get_url_params(context=None, next_page_token=None)
+
+    assert params["jql"] == (
+        "(created>='2026-01-01 13:34' or updated>='2026-01-01 13:34') and "
+        "(created<'2026-02-01 01:00' or updated<'2026-02-01 01:00') and (id != null) "
+        "order by updated asc"
+    )


### PR DESCRIPTION
Jira evaluates date literals in JQL in the timezone of the authenticated user, but the issues stream formatted the replication bookmark and `end_date` as UTC wall-clock time. For any account not on UTC this shifts the incremental window, causing records to be skipped or re-synced.

Add a `timezone` setting (IANA name, default `UTC`) that is used to render the date literals. Naive datetimes are assumed to be UTC.